### PR TITLE
修正0041.岛屿数量c++解法的dfs答案

### DIFF
--- a/problems/0041.岛屿数量.md
+++ b/problems/0041.岛屿数量.md
@@ -43,7 +43,8 @@ void solve() {
     vector<vector<int>> grid(n, vector<int>(m, 0)); // 地图
     int control; // 操作数
     cin >> control;
-    int ans = 0;
+    int ans = 0; // 答案
+    int num = 1; // 编号
     while(control--) {
         int x;
         int y;
@@ -55,9 +56,11 @@ void solve() {
         }
         // 岛屿数量增加
         ans++;
-        // 将新岛屿编号
-        grid[x][y] = ans;
+        // 将新岛屿编号,num是不断增加的,故不会重复
+        grid[x][y] = num;
         unordered_set<int> st; // 用来储存不同的岛屿
+        // 将新的编号存入set
+        st.insert(grid[x][y]);
         // 遍历四个方向
         for(int i = 0; i < 4; ++i) {
             int nx = x + dir[i][0];
@@ -77,12 +80,12 @@ void solve() {
         vector<vector<bool>> visited(n, vector<bool>(m, false)); // 储存访问情况
         // 标记为已经访问
         visited[x][y] = true;
-        // 将编号改为我们新得到的ans
-        grid[x][y] = ans;
-        // 将所有与当前操作的岛屿连通的岛屿都编号为我们新得到的ans
-        dfs(grid, visited, x, y, ans);
+        // 将所有与当前操作的岛屿连通的岛屿都编号为新的编号num
+        dfs(grid, visited, x, y, num);
         // 输出答案
         cout << ans << " ";
+        // 预先增加编号
+        num++;
     }
     cout << endl;
 }


### PR DESCRIPTION
0041.岛屿数量c++解法的dfs答案曾经无法通过如下测试用例：
4
4
7
0 0
1 1
1 2
2 3
0 1
3 2
3 3
预期输出：1 2 2 3 2 3 2
现通过添加独立的num变量用来给岛屿编号已经解决该问题