### PR TITLE
Update: 27. 最长增长子序列（第一期模拟笔试），添加新解法(Java、Python)

### DIFF
--- a/problems/0027.最长增长子序列.md
+++ b/problems/0027.最长增长子序列.md
@@ -99,6 +99,146 @@ public class Main {
 }
 ```
 
+方法二：
+
+```java
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+        sc.nextLine();
+        for (int i = 0; i < N; i++) {
+            String s = sc.nextLine();
+            String[] ss = s.replaceAll("[\\[\\]\\s]", "").split(",");
+            int[] nums = new int[ss.length];
+            for (int j = 0; j < ss.length; j++)
+                nums[j] = Integer.parseInt(ss[j]);
+
+            // 贪心
+            lengthOfLIS(nums);
+            // lengthOfLIS2(nums);
+
+            // 动态规划
+            // lengthOfLIS3(nums);
+            // lengthOfLIS4(nums);
+
+        }
+        sc.close();
+    }
+
+    // region 贪心 + 二分查找
+
+    // 一、使用额外空间
+    // 时间复杂度: O(nlogn), n为nums的长度
+    // 空间复杂度: O(n)
+    static void lengthOfLIS(int[] nums) {
+        List<Integer> g = new ArrayList<>();
+        for (int x : nums) {
+            int j = lowerBound(g, x);
+            if (j == g.size()) // >= x 的g[j]不存在
+                g.add(x);
+            else
+                g.set(j, x);
+        }
+        System.out.println(g.size());
+    }
+
+    // 二分查找 <= target 的最大下标，若没有，返回g的长度（开区间）
+    static int lowerBound(List<Integer> g, int target) {
+        int left = -1, right = g.size();
+        while (left + 1 < right) {
+            int mid = (left + right) >>> 1;
+            if (g.get(mid) < target) {
+                left = mid;
+            } else {
+                right = mid;
+            }
+        }
+        return right;
+    }
+
+    // 二、原地修改
+    // 时间复杂度: O(nlogn), n为nums的长度
+    // 空间复杂度: O(1)
+    static void lengthOfLIS2(int[] nums) {
+        int ng = 0; // g 的长度
+        for (int x : nums) {
+            int j = lowerBound2(nums, ng, x);
+            nums[j] = x;
+            if (j == ng) // >= x 的g[i]不存在
+                ng++;
+        }
+        System.out.println(ng);
+    }
+
+    static int lowerBound2(int[] nums, int right, int target) {
+        int left = -1;
+        while (left + 1 < right) {
+            int mid = (left + right) >>> 1;
+            if (nums[mid] < target) {
+                left = mid;
+            } else {
+                right = mid;
+            }
+        }
+        return right;
+    }
+
+    // endregion
+
+    // region 动态规划【枚举选哪个】
+    // 时间复杂度: O(n^2), n为nums的长度
+    // 空间复杂度: O(n)
+
+    // 一、记忆化搜索
+    static void lengthOfLIS3(int[] nums) {
+        int n = nums.length;
+        int[] memo = new int[n];
+        int ans = 0;
+        for (int i = 0; i < n; i++) {
+            ans = Math.max(ans, dfs(i, nums, memo));
+        }
+        System.out.println(ans);
+    }
+
+    // nums, memo可以提出去，作为全局变量存在
+    static int dfs(int i, int[] nums, int[] memo) {
+        if (memo[i] > 0)
+            return memo[i];
+
+        for (int j = 0; j < i; j++) {
+            if (nums[j] < nums[i]) {
+                memo[i] = Math.max(memo[i], dfs(j, nums, memo));
+            }
+        }
+        return ++memo[i];
+    }
+
+    // 二、递推
+    static void lengthOfLIS4(int[] nums) {
+        int n = nums.length, ans = 0;
+        int[] dp = new int[n];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < i; j++) {
+                if (nums[j] < nums[i]) {
+                    dp[i] = Math.max(dp[j], dp[i]);
+                }
+            }
+            ans = Math.max(ans, ++dp[i]);
+        }
+        System.out.println(ans);
+    }
+
+    // endregion
+
+}
+```
+
+
+
 ## Python
 
 ```python
@@ -123,6 +263,102 @@ for _ in range(t):
     # 找到dp中的最大值
     print(max(dp))
 ```
+方法二：
+
+```python
+def length_of_LIS(nums: list) -> None:
+    """贪心 + 二分查找"""
+    def lowerBound(g: list, target: int) -> int:
+        left, right = -1, len(g)
+        while left + 1 < right:
+            mid = (left + right) // 2
+            if g[mid] < target:
+                left = mid
+            else:
+                right = mid
+        return right
+
+    g = []
+    for x in nums:
+        j = lowerBound(g, x)
+        if j == len(g):  # >= x的g[j]不存在
+            g.append(x)
+        else:
+            g[j] = x
+    print(len(g))
+
+
+def length_of_LIS_2(nums: list) -> None:
+    """贪心 + 二分查找"""
+    def lower_bound(nums: list, target: int, left: int, right: int) -> int:
+        while left + 1 < right:
+            mid = (left + right) // 2
+            if nums[mid] < target:
+                left = mid
+            else:
+                right = mid
+        return right
+
+    ng = 0
+    for x in nums:
+        j = lower_bound(nums, x, -1, ng)
+        nums[j] = x
+        if j == ng:  # >= x的g[j]不存在
+            ng += 1
+    print(ng)
+
+
+def length_of_LIS_3(nums: list) -> None:
+    """动态规划（dfs）"""
+    n = len(nums)
+
+    # dfs(i) 表示以i结尾的最长递增子序列长度
+    # @cache # from functools import cache
+    def dfs(i: int) -> int:
+        res = 0
+        for j in range(i):
+            if nums[j] < nums[i]:
+                res = max(res, dfs(j))
+        return res + 1
+
+    ans = 0
+    for i in range(n):
+        ans = max(ans, dfs(i))
+    return ans
+
+
+def length_of_LIS_4(nums: list) -> None:
+    """动态规划（递推）"""
+    n = len(nums)
+    # dp[i] 表示以i结尾的最长递增子序列长度
+    dp = [0] * n
+    for i in range(n):
+        for j in range(i):
+            if nums[j] < nums[i]:
+                dp[i] = max(dp[i], dp[j])
+        dp[i] += 1
+    print(max(dp))
+
+
+if __name__ == "__main__":
+    N = int(input())
+    for _ in range(N):
+        s = input()
+        nums = list(
+            map(int, s.replace("[", "").replace("]", "").replace(" ", "").split(",")))
+
+        # 贪心
+        length_of_LIS(nums)
+        # length_of_LIS_2(nums)
+
+        # 动态规划
+        # length_of_LIS_3(nums) # 因为无法引入functools.cache，此方法可以在本地跑，kama网上不能跑通，力扣上可以跑通
+        # length_of_LIS_4(nums)
+
+```
+
+
+
 ## Go
 
 ```go


### PR DESCRIPTION
最长增长子序列（第一期模拟笔试），添加贪心解法 + 动态规划解法（四种写法）。

此外，在使用Python解题的时候，发现`@cache`装饰器不能引入
`from functools import cache`引入语句就直接报错了，报错信息`ImportError: cannot import name 'cache' from 'functools' (/usr/lib/python3.8/functools.py)`，想问下Carl哥，这是网站设计好的嘛🤣 @youngyangyang04 
【PS：这种情况我已经在代码中注释了，提醒了看到我代码的录友了】